### PR TITLE
Setuptools python2 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ IN_VENV=. ./venv/bin/activate
 venv/bin/activate:
 	test -d venv || virtualenv venv --prompt '(panga) ' --python=python2
 	${IN_VENV} && pip install pip --upgrade
+	${IN_VENV} && pip install "setuptools<45"
 	${IN_VENV} && pip install distribute --no-binary distribute
 	${IN_VENV} && pip install -r install_requires.txt 
 	${IN_VENV} && pip install -r requirements.txt; 


### PR DESCRIPTION
Setuptools >= 45 removes support for python2. Install setuptools<45 in makefile to allow successful installation.